### PR TITLE
Handle v1 tablets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,16 +6,25 @@ fn send_usb_request(device: &Device) {
     // See the uclogic driver
     const MAGIC_LANGUAGE_ID: u16 = 0x409;
     handle.read_languages(timeout).unwrap().iter().filter(|l| l.lang_id() == MAGIC_LANGUAGE_ID).for_each(|lang| {
+        // Firmware call for Huion devices
+        let s = handle.read_string_descriptor(*lang, 201, timeout).unwrap();
+        println!("HUION_FIRMWARE_ID={s}");
         // Get the pen input parameters, see uclogic_params_pen_init_v2()
         // This retrieves magic configuratino parameters but more importantly
         // switches the tablet to send events on the 0x8 Report ID (88 bits of Vendor Usage in
         // Usage Page 0x00FF).
         let s = handle.read_string_descriptor(*lang, 200, timeout).unwrap();
-        let bytes: Vec<String> = s.as_bytes().iter().map(|b| format!("{b:02x}")).collect();
-        println!("HUION_MAGIC_BYTES={}", bytes.join(""));
-        // Firmware call for Huion devices
-        let s = handle.read_string_descriptor(*lang, 201, timeout).unwrap();
-        println!("HUION_FIRMWARE_ID={s}");
+        if s.as_bytes().len() >= 18 {
+            let bytes: Vec<String> = s.as_bytes().iter().map(|b| format!("{b:02x}")).collect();
+            println!("HUION_MAGIC_BYTES={}", bytes.join(""));
+        } else {
+            let s = handle.read_string_descriptor(*lang, 100, timeout).unwrap();
+            let bytes: Vec<String> = s.as_bytes().iter().map(|b| format!("{b:02x}")).collect();
+            println!("HUION_MAGIC_BYTES={}", bytes.join(""));
+            // switch the buttons into raw mode
+            let s = handle.read_string_descriptor(*lang, 123, timeout).unwrap();
+            println!("HUION_PAD_MODE={s}");
+        }
     });
 }
 


### PR DESCRIPTION
The v1 tablets need to poll 2 different string descriptors to switch into raw mode