### PR TITLE
Re-export parent properties if called with a syspath

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: test suite
 on: [push, pull_request]
 
 env:
-  UBUNTU_PACKAGES: libusb-1.0.0
+  UBUNTU_PACKAGES: libusb-1.0.0 libusb-1.0-0-dev
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: test suite
 on: [push, pull_request]
 
 env:
-  UBUNTU_PACKAGES: libusb-1.0.0 libusb-1.0-0-dev
+  UBUNTU_PACKAGES: libusb-1.0.0 libusb-1.0-0-dev libudev-dev
 
 jobs:
   test:

--- a/80-huion-switcher.rules
+++ b/80-huion-switcher.rules
@@ -1,2 +1,2 @@
 # huion-switcher must live in /usr/lib/udev/
-ACTION=="bind", SUBSYSTEM=="usb", ATTR{idVendor}=="256c", IMPORT{program}="huion-switcher"
+ACTION=="bind", ATTRS{idVendor}=="256c", IMPORT{program}="huion-switcher %S%p"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "bit-set"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,10 +24,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "huion-switcher"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "libusb",
+ "udev",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -29,6 +54,16 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libusb"
@@ -56,3 +91,81 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "udev"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50051c6e22be28ee6f217d50014f3bc29e81c20dc66ff7ca0d5c5226e1dcc5a1"
+dependencies = [
+ "io-lifetimes",
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.86"
 libusb = "0.3.0"
+udev = "0.8.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
+use anyhow::Result;
 use libusb::*;
+use std::path::PathBuf;
 
-fn send_usb_request(device: &Device) {
+fn send_usb_request(device: &Device) -> Result<()> {
     let timeout = std::time::Duration::from_millis(100);
-    let handle = device.open().unwrap();
+    let handle = device.open()?;
     // See the uclogic driver
     const MAGIC_LANGUAGE_ID: u16 = 0x409;
     handle
@@ -31,24 +33,66 @@ fn send_usb_request(device: &Device) {
                 println!("HUION_PAD_MODE={s}");
             }
         });
+
+    Ok(())
 }
 
-fn main() {
+fn send_usb() -> Result<()> {
     let ctx = Context::new().unwrap();
 
     const HUION_VENDOR_ID: u16 = 0x256C;
 
-    ctx.devices()
-        .unwrap()
-        .iter()
-        .filter(|d| {
-            if let Ok(desc) = d.device_descriptor() {
-                desc.vendor_id() == HUION_VENDOR_ID
-            } else {
-                false
+    for device in ctx.devices().unwrap().iter().filter(|d| {
+        if let Ok(desc) = d.device_descriptor() {
+            desc.vendor_id() == HUION_VENDOR_ID
+        } else {
+            false
+        }
+    }) {
+        send_usb_request(&device)?;
+    }
+
+    Ok(())
+}
+
+fn search_udev(path: &str) -> Result<()> {
+    let path = PathBuf::from(path);
+    let mut device = udev::Device::from_syspath(&path)?;
+    let properties: Vec<&str> = vec!["HUION_FIRMWARE_ID", "HUION_MAGIC_BYTES", "HUION_PAD_MODE"];
+
+    loop {
+        // We expect all properties to be set on the same device
+        if properties.iter().any(|p| {
+            let v = device.property_value(p);
+            if let Some(v) = v {
+                println!("{p}={}", v.to_string_lossy());
             }
-        })
-        .for_each(|d| {
-            send_usb_request(&d);
-        });
+            v.is_some()
+        }) {
+            break;
+        }
+
+        if let Some(parent) = device.parent() {
+            device = parent;
+        } else {
+            // we're out of udev parents so no device has the
+            // property set yet. Which means we should send the USB request.
+            send_usb()?;
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let strs: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
+    let rc = match &strs[..] {
+        [path] => search_udev(path),
+        _ => send_usb(),
+    };
+    if let Err(e) = rc {
+        eprintln!("Error: {e}");
+    }
 }


### PR DESCRIPTION
If we call this tool with a syspath argument, run up the udev device parents to search for the various properties we set. If we find any, re-export them.

In the udev rule we can then call this tool for each matching syspath and will just copy the udev property up instead of re-running the usb command.

Finally, in the udev rule we can copy the value over to UNIQ and HID_UNIQ depending on the device we have.

No, for some reason IMPORT{parent} did not work for the HUION properties we're adding...


cc @bentiss, @JoseExposito

---

I spent a long time trying to make `IMPORT{parent}` work in the udev rule so we didn't need this. I could bubble up all other properties but not ours, my best guess without having to read the udev sources is that there's some race condition  - the property is visible to the udev rules but somehow not to `IMPORT{parent}`.