### PR TITLE
udev: copy the HUION_FIRMWARE_ID into (HID_)UNIQ

### DIFF
--- a/80-huion-switcher.rules
+++ b/80-huion-switcher.rules
@@ -1,2 +1,6 @@
 # huion-switcher must live in /usr/lib/udev/
-ACTION=="bind", ATTRS{idVendor}=="256c", IMPORT{program}="huion-switcher %S%p"
+ACTION!="add|remove|bind", GOTO="huion_switcher_end"
+ATTRS{idVendor}=="256c", IMPORT{program}="huion-switcher %S%p"
+ATTRS{idVendor}=="256c", ENV{HID_UNIQ}=="", ENV{HUION_FIRMWARE_ID}!="", ENV{HID_UNIQ}="$env{HUION_FIRMWARE_ID}"
+ATTRS{idVendor}=="256c", ENV{UNIQ}=="", ENV{HUION_FIRMWARE_ID}!="", ENV{UNIQ}="$env{HUION_FIRMWARE_ID}"
+LABEL="huion_switcher_end"


### PR DESCRIPTION
libwacom relies on UNIQ to be parse the tools firmware id, so let's make sure we copy that over. This now roughly matches the behaviour of the DIGIMEND driver.

Since huion-switcher now copies the properties we can run it safely enough on all actions - we need to run it on add now too to make sure our properties get set correctly.