### PR TITLE
convert to use rusb instead of libusb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,19 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
-name = "bit-set"
-version = "0.2.0"
+name = "cc"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e1e6fb1c9e3d6fcdec57216a74eaa03e41f52a22f13a16438251d8e88b89da"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "hermit-abi"
@@ -31,10 +22,10 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "huion-switcher"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
- "libusb",
+ "rusb",
  "udev",
 ]
 
@@ -66,24 +57,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "libusb"
-version = "0.3.0"
+name = "libusb1-sys"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f990ddd929cbe53de4ecd6cf26e1f4e0c5b9796e4c629d9046570b03738aa53"
+checksum = "da050ade7ac4ff1ba5379af847a10a10a8e284181e060105bf8d86960ce9ce0f"
 dependencies = [
- "bit-set",
- "libc",
- "libusb-sys",
-]
-
-[[package]]
-name = "libusb-sys"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c53b6582563d64ad3e692f54ef95239c3ea8069e82c9eb70ca948869a7ad767"
-dependencies = [
+ "cc",
  "libc",
  "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -91,6 +73,16 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "rusb"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9f9ff05b63a786553a4c02943b74b34a988448671001e9a27e2f0565cc05a4"
+dependencies = [
+ "libc",
+ "libusb1-sys",
+]
 
 [[package]]
 name = "udev"
@@ -103,6 +95,12 @@ dependencies = [
  "libudev-sys",
  "pkg-config",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ description = "Utility to switch Huion tablets into tablet mode"
 
 [dependencies]
 anyhow = "1.0.86"
-libusb = "0.3.0"
+rusb = "0.9.4"
 udev = "0.8.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,13 +98,17 @@ fn search_udev(path: &str) -> Result<()> {
 
     loop {
         // We expect all properties to be set on the same device
-        if properties.iter().any(|p| {
-            let v = device.property_value(p);
-            if let Some(v) = v {
-                println!("{p}={}", v.to_string_lossy());
-            }
-            v.is_some()
-        }) {
+        if properties
+            .iter()
+            .map(|p| {
+                let v = device.property_value(p);
+                if let Some(v) = v {
+                    println!("{p}={}", v.to_string_lossy());
+                }
+                v.is_some()
+            })
+            .fold(false, |acc, x| acc || x)
+        {
             break;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
-use libusb;
+use rusb;
+use rusb::UsbContext;
 use std::path::{Path, PathBuf};
 
-fn send_usb_request(device: &libusb::Device) -> Result<()> {
+fn send_usb_request(device: &rusb::Device<rusb::Context>) -> Result<()> {
     let timeout = std::time::Duration::from_millis(100);
     let handle = device.open()?;
     // See the uclogic driver
@@ -38,7 +39,7 @@ fn send_usb_request(device: &libusb::Device) -> Result<()> {
 }
 
 fn send_usb_to_all() -> Result<()> {
-    let ctx = libusb::Context::new().unwrap();
+    let ctx = rusb::Context::new().unwrap();
 
     const HUION_VENDOR_ID: u16 = 0x256C;
 
@@ -79,7 +80,7 @@ fn send_usb_to_device(path: &Path) -> Result<()> {
     let bus = str::parse(&busnum.to_string_lossy())?;
     let addr = str::parse(&devnum.to_string_lossy())?;
 
-    let ctx = libusb::Context::new().unwrap();
+    let ctx = rusb::Context::new().unwrap();
     let rc = ctx
         .devices()
         .unwrap()


### PR DESCRIPTION
libusb has been unmaintained for a while now:
https://github.com/dcuddeback/libusb-rs/issues/49 (and last commit from 8 years ago)

Convert to rusb, so we get updates in crates.