### PR TITLE
Fix the magic bytes handling (again, possibly)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,8 @@ fn send_usb_request(device: &rusb::Device<rusb::Context>) -> Result<()> {
     // Firmware call for Huion devices
     // Note: yes, this is a normal read_string_descriptor, see hid-uclogic
     let s = handle.read_string_descriptor(lang, 201, timeout)?;
-    println!("HUION_FIRMWARE_ID={s}");
+    let s = s.trim_end_matches('\0');
+    println!("HUION_FIRMWARE_ID={s:?}");
 
     // Get the pen input parameters, see uclogic_params_pen_init_v2()
     // This retrieves magic configuration parameters but more importantly

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,12 @@ use rusb;
 use rusb::{DeviceHandle, Language, UsbContext};
 use std::path::{Path, PathBuf};
 
+fn utf16_to_be_string(s: &str) -> String {
+    s.encode_utf16()
+        .map(|b| format!("{:04x}", b.to_be()))
+        .collect()
+}
+
 fn string_descriptor(
     handle: &DeviceHandle<rusb::Context>,
     lang: &Language,
@@ -38,12 +44,12 @@ fn send_usb_request(device: &rusb::Device<rusb::Context>) -> Result<()> {
             // Usage Page 0x00FF).
             let s = string_descriptor(&handle, lang, 200)?;
             if s.as_bytes().len() >= 18 {
-                let bytes: Vec<String> = s.as_bytes().iter().map(|b| format!("{b:02x}")).collect();
-                println!("HUION_MAGIC_BYTES={}", bytes.join(""));
+                let bytes = utf16_to_be_string(&s);
+                println!("HUION_MAGIC_BYTES={bytes}");
             } else {
                 let s = string_descriptor(&handle, lang, 100)?;
-                let bytes: Vec<String> = s.as_bytes().iter().map(|b| format!("{b:02x}")).collect();
-                println!("HUION_MAGIC_BYTES={}", bytes.join(""));
+                let bytes = utf16_to_be_string(&s);
+                println!("HUION_MAGIC_BYTES={bytes}");
                 // switch the buttons into raw mode
                 let s = string_descriptor(&handle, lang, 123)?;
                 println!("HUION_PAD_MODE={s}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn send_usb_request(device: &rusb::Device<rusb::Context>) -> Result<()> {
     // uclogic_params_pen_init_v2()
     match huion_string_descriptor(&handle, &lang, 100) {
         Ok(bytes) => {
-            if bytes.len() == 12 {
+            if bytes.len() >= 12 {
                 let bytes = bytestring(&bytes);
                 println!("HUION_MAGIC_BYTES={bytes}");
                 // switch the buttons into raw mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ fn send_usb_request(device: &rusb::Device<rusb::Context>) -> Result<()> {
         .read_languages(timeout)
         .unwrap()
         .iter()
-        .filter(|l| l.lang_id() == MAGIC_LANGUAGE_ID)
-        .for_each(|lang| {
+        .find(|l| l.lang_id() == MAGIC_LANGUAGE_ID)
+        .map(|lang| {
             // Firmware call for Huion devices
             let s = handle.read_string_descriptor(*lang, 201, timeout).unwrap();
             println!("HUION_FIRMWARE_ID={s}");


### PR DESCRIPTION
This supersedes #6 and hopefully works for that device too.

Turns out rusb's `read_string_descriptor()` **cannot** work on some devices because it expects an even-length buffer and the Kamvas 12 returns a buffer length 19. So we need to do this manually. And to be doubly safe, do exactly what hid-uclogic does with two "normal" string reads and two "special" reads that return the buffer as-is, including header bytes.

The PR could be rebased but that's too much effort at this point...

cc @bentiss