### PR TITLE
Auto-release with a built binary on tag pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ env:
   UBUNTU_PACKAGES: libusb-1.0.0 libusb-1.0-0-dev libudev-dev
 
 jobs:
-  test:
+  build-and-test:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
@@ -23,3 +23,23 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo fmt --check
+
+  release-build:
+     name: cargo build --release
+     runs-on: ubuntu-22.04
+     needs: [build-and-test]
+     steps:
+       - uses: actions/checkout@v4
+       - uses: dtolnay/rust-toolchain@stable
+       - uses: linuxwacom/libwacom/.github/actions/pkginstall@master
+         with:
+           apt: $UBUNTU_PACKAGES
+       - run: cargo build --release
+       - run: cp target/release/huion-switcher .
+       - uses: actions/upload-artifact@v4
+         with:
+           name: huion-switcher
+           path: |
+             huion-switcher
+             README.md
+             *.rules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,3 +43,18 @@ jobs:
              huion-switcher
              README.md
              *.rules
+
+  create-release:
+    runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [release-build]
+    permissions:
+      contents: write
+    steps:
+      - uses: dawidd6/action-download-artifact@v6
+        with:
+          name: huion-switcher
+          skip_unpack: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: huion-switcher.zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "huion-switcher"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "rusb",

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ $ sudo cargo build
 $ sudo cargo run
 ```
 
+Alternatively you can download a pre-built binary from the
+[latest release](https://github.com/whot/huion-switcher/releases). Look for the
+`huion-switcher.zip` that's attached to the release (and built by our
+[CI workflow](https://github.com/whot/huion-switcher/blob/main/.github/workflows/main.yml)):
+
+```
+$ unzip huion-switcher.zip
+$ chmod +x huion-switcher
+$ sudo ./huion-switcher
+```
+Or see the `Installing` section below for installing ready for a udev invocation.
+
 ## Installing
 
 ```


### PR DESCRIPTION
Build a `cargo --release` version and attach it to or workflow so users can quickly test the current state of the repo. And whenever a tag is pushed, attach that to the release itself.

cc @bentiss 