### PR TITLE
Only run huion-switcher on hidraw nodes

### DIFF
--- a/80-huion-switcher.rules
+++ b/80-huion-switcher.rules
@@ -1,6 +1,6 @@
 # huion-switcher must live in /usr/lib/udev/
 ACTION!="add|remove|bind", GOTO="huion_switcher_end"
-ATTRS{idVendor}=="256c", IMPORT{program}="huion-switcher %S%p"
+ATTRS{idVendor}=="256c", SUBSYSTEM=="hidraw", IMPORT{program}="huion-switcher %S%p"
 ATTRS{idVendor}=="256c", ENV{HID_UNIQ}=="", ENV{HUION_FIRMWARE_ID}!="", ENV{HID_UNIQ}="$env{HUION_FIRMWARE_ID}"
 ATTRS{idVendor}=="256c", ENV{UNIQ}=="", ENV{HUION_FIRMWARE_ID}!="", ENV{UNIQ}="$env{HUION_FIRMWARE_ID}"
 LABEL="huion_switcher_end"


### PR DESCRIPTION
Previously we'd run on anything that had the vendor id set, including mouse and event ndoes. No point doing that.

cc @bentiss for an extra pair of eyes