### PR TITLE
Replace a fold() with a for loop + bool

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -165,17 +165,14 @@ fn search_udev(path: &str) -> Result<()> {
 
     loop {
         // We expect all properties to be set on the same device
-        if properties
-            .iter()
-            .map(|p| {
-                let v = device.property_value(p);
-                if let Some(v) = v {
-                    println!("{p}={}", v.to_string_lossy());
-                }
-                v.is_some()
-            })
-            .fold(false, |acc, x| acc || x)
-        {
+        let mut found = false;
+        for p in &properties {
+            if let Some(v) = device.property_value(p) {
+                println!("{p}={}", v.to_string_lossy());
+                found = true;
+            }
+        }
+        if found {
             break;
         }
 


### PR DESCRIPTION
The fold feels fancy but clippy complains about it, suggesting any(). That doesn't actually work because we don't want it to shortcut, we need to always do all properties.

So let's replace it with a for loop which clippy is happy about and is probably also more clear it any unsuspecting reader.